### PR TITLE
Fixes #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ pnpm-debug.log
 
 package-lock.json
 shrinkwrap.yaml
+
+.project
+.settings

--- a/index.js
+++ b/index.js
@@ -3,8 +3,15 @@
 const deepStrictEqual = require('deep-strict-equal')
 const rewind = require('@turf/rewind')
 
-const parseCoords = (s, transformCoords, stride = 2) => {
+const noTransform = (...coords) => coords
+
+const parseCoords = (s, opts = { transformCoords: noTransform, stride: 2 }, ctx = {} ) => {
+	const stride = ctx.srsDimension || opts.stride || 2;
+
+	const transformCoords = opts.transformCoords || noTransform;
+
 	const coords = s.replace(/\s+/g, ' ').trim().split(' ')
+
 	if (coords.length === 0 || (coords.length % stride) !== 0) {
 		console.error(coords) // todo
 		throw new Error(`invalid coordinates list (stride ${stride})`)
@@ -36,45 +43,51 @@ const findIn = (root, ...tags) => {
 	return el
 }
 
-const parsePosList = (_, transformCoords, stride = 2) => {
+const createChildContext = (_, opts, ctx) => {
+	const srsDimensionAttribute = _.attributes && _.attributes.srsDimension
+	if (srsDimensionAttribute) {
+		const srsDimension = parseInt(srsDimensionAttribute)
+		if (Number.isNaN(srsDimension) || srsDimension <= 0) throw new Error(`invalid srsDimension attribute value "${srsDimensionAttribute}", expected a positive integer`)
+
+		const childCtx = Object.create(ctx)
+		childCtx.srsDimension = srsDimension
+		return childCtx;
+	} else {
+		return ctx;
+	}
+}
+
+const parsePosList = (_, opts, ctx = {}) => {
 	const coords = textOf(_)
 	if (!coords) throw new Error('invalid gml:posList element')
 
-	const dimensions = _.attributes && _.attributes.srsDimension
-	if (dimensions) {
-		stride = parseInt(dimensions)
-		if (Number.isNaN(stride)) throw new Error('invalid posList:srsDimension attribute')
-	}
-	return parseCoords(coords, transformCoords, stride)
+	const childCtx = createChildContext(_, opts, ctx);
+	return parseCoords(coords, opts, childCtx);
 }
 
-const parsePos = (_, transformCoords, stride = 2) => {
+const parsePos = (_, opts, ctx = {}) => {
 	const coords = textOf(_)
 	if (!coords) throw new Error('invalid gml:pos element')
 
-	const dimensions = _.attributes && _.attributes.srsDimension
-	if (dimensions) {
-		stride = parseInt(dimensions)
-		if (Number.isNaN(stride)) throw new Error('invalid posList:srsDimension attribute')
-	}
-	const points = parseCoords(coords, transformCoords, stride)
+	const childCtx = createChildContext(_, opts, ctx);
+	const points = parseCoords(coords, opts, childCtx)
 	if (points.length !== 1) throw new Error('gml:pos must have 1 point')
 	return points[0]
 }
 
-const parseLinearRingOrLineString = (_, transformCoords, stride = 2) => { // or a LineStringSegment
+const parseLinearRingOrLineString = (_, opts, ctx = {}) => { // or a LineStringSegment
 	let points = []
 
 	const posList = findIn(_, 'gml:posList')
-	if (posList) points = parsePosList(posList, transformCoords, stride)
+	if (posList) points = parsePosList(posList, opts, ctx)
 	else {
 		for (let c of _.children) {
 			if (c.name === 'gml:Point') {
 				const pos = findIn(c, 'gml:pos')
 				if (!pos) continue
-				points.push(parsePos(pos, transformCoords))
+				points.push(parsePos(pos, opts, ctx))
 			} else if (c.name === 'gml:pos') {
-				points.push(parsePos(c, transformCoords))
+				points.push(parsePos(c, opts, ctx))
 			}
 		}
 	}
@@ -83,12 +96,12 @@ const parseLinearRingOrLineString = (_, transformCoords, stride = 2) => { // or 
 	return points
 }
 
-const parseCurveSegments = (_, transformCoords, stride = 2) => {
+const parseCurveSegments = (_, opts, ctx = {}) => {
 	let points = []
 
 	for (let c of _.children) {
 		if (c.name !== 'gml:LineStringSegment') continue
-		const points2 = parseLinearRingOrLineString(c, transformCoords, stride)
+		const points2 = parseLinearRingOrLineString(c, opts, ctx)
 
 		// remove overlapping
 		const end = points[points.length - 1]
@@ -104,7 +117,7 @@ const parseCurveSegments = (_, transformCoords, stride = 2) => {
 	return points
 }
 
-const parseRing = (_, transformCoords, stride = 2) => {
+const parseRing = (_, opts, ctx = {}) => {
 	const points = []
 
 	for (let c of _.children) {
@@ -113,12 +126,12 @@ const parseRing = (_, transformCoords, stride = 2) => {
 
 		const lineString = findIn(c, 'gml:LineString')
 		if (lineString) {
-			points2 = parseLinearRingOrLineString(lineString, transformCoords, stride)
+			points2 = parseLinearRingOrLineString(lineString, opts, ctx)
 		} else {
 			const segments = findIn(c, 'gml:Curve', 'gml:segments')
 			if (!segments) throw new Error('invalid ' + c.name + ' element')
 
-			points2 = parseCurveSegments(segments, transformCoords, stride)
+			points2 = parseCurveSegments(segments, opts, ctx)
 		}
 
 		// remove overlapping
@@ -133,57 +146,57 @@ const parseRing = (_, transformCoords, stride = 2) => {
 	return points
 }
 
-const parseExteriorOrInterior = (_, transformCoords, stride = 2) => {
+const parseExteriorOrInterior = (_, opts, ctx = {}) => {
 	const linearRing = findIn(_, 'gml:LinearRing')
 	if (linearRing) {
-		return parseLinearRingOrLineString(linearRing, transformCoords, stride)
+		return parseLinearRingOrLineString(linearRing, opts, ctx)
 	}
 
 	const ring = findIn(_, 'gml:Ring')
-	if (ring) return parseRing(ring, transformCoords, stride)
+	if (ring) return parseRing(ring, opts, ctx)
 
 	throw new Error('invalid ' + _.name + ' element')
 }
 
-const parsePolygonOrRectangle = (_, transformCoords, stride = 2) => { // or PolygonPatch
+const parsePolygonOrRectangle = (_, opts, ctx = {}) => { // or PolygonPatch
 	const exterior = findIn(_, 'gml:exterior')
 	if (!exterior) throw new Error('invalid ' + _.name + ' element')
 
 	const pointLists = [
-		parseExteriorOrInterior(exterior, transformCoords, stride)
+		parseExteriorOrInterior(exterior, opts, ctx)
 	]
 
 	for (let c of _.children) {
 		if (c.name !== 'gml:interior') continue
-		pointLists.push(parseExteriorOrInterior(c, transformCoords, stride))
+		pointLists.push(parseExteriorOrInterior(c, opts, ctx))
 	}
 
 	return pointLists
 }
 
-const parseSurface = (_, transformCoords, stride = 2) => {
+const parseSurface = (_, opts, ctx = {}) => {
 	const patches = findIn(_, 'gml:patches')
 	if (!patches) throw new Error('invalid ' + _.name + ' element')
 
 	const polygons = []
 	for (let c of patches.children) {
 		if (c.name !== 'gml:PolygonPatch' && c.name !== 'gml:Rectangle') continue
-		polygons.push(parsePolygonOrRectangle(c, transformCoords, stride))
+		polygons.push(parsePolygonOrRectangle(c, opts, ctx))
 	}
 
 	if (polygons.length === 0) throw new Error(_.name + ' must have > 0 polygons')
 	return polygons
 }
 
-const parseCompositeSurface = (_, transformCoords, stride = 2) => {
+const parseCompositeSurface = (_, opts, ctx = {}) => {
 	const polygons = []
 	for (let c of _.children) {
 		if (c.name === 'gml:surfaceMember') {
 			const c2 = c.children[0]
 			if (c2.name === 'gml:Surface') {
-				polygons.push(...parseSurface(c2, transformCoords, stride))
+				polygons.push(...parseSurface(c2, opts, ctx))
 			} else if (c2.name === 'gml:Polygon') {
-				polygons.push(parsePolygonOrRectangle(c2, transformCoords, stride))
+				polygons.push(parsePolygonOrRectangle(c2, opts, ctx))
 			}
 		}
 	}
@@ -192,7 +205,7 @@ const parseCompositeSurface = (_, transformCoords, stride = 2) => {
 	return polygons
 }
 
-const parseMultiSurface = (_, transformCoords, stride = 2) => {
+const parseMultiSurface = (_, opts, ctx = {}) => {
 	let el = _
 
 	const surfaceMembers = findIn(_, 'gml:LinearRing')
@@ -201,16 +214,16 @@ const parseMultiSurface = (_, transformCoords, stride = 2) => {
 	const polygons = []
 	for (let c of el.children) {
 		if (c.name === 'gml:Surface') {
-			const polygons2 = parseSurface(c, transformCoords, stride)
+			const polygons2 = parseSurface(c, opts, ctx)
 			polygons.push(...polygons2)
 		} else if (c.name === 'gml:surfaceMember') {
 			const c2 = c.children[0]
 			if (c2.name === 'gml:CompositeSurface') {
-				polygons.push(...parseCompositeSurface(c2, transformCoords, stride))
+				polygons.push(...parseCompositeSurface(c2, opts, ctx))
 			} else if (c2.name === 'gml:Surface') {
-				polygons.push(...parseSurface(c2, transformCoords, stride))
+				polygons.push(...parseSurface(c2, opts, ctx))
 			} else if (c2.name === 'gml:Polygon') {
-				polygons.push(parsePolygonOrRectangle(c2, transformCoords, stride))
+				polygons.push(parsePolygonOrRectangle(c2, opts, ctx))
 			}
 		}
 	}
@@ -219,23 +232,21 @@ const parseMultiSurface = (_, transformCoords, stride = 2) => {
 	return polygons
 }
 
-const noTransform = (...coords) => coords
-
-const parse = (_, transformCoords = noTransform, stride = 2) => {
+const parse = (_, opts = { transformCoords: noTransform, stride: 2 }, ctx = {}) => {
 	if (_.name === 'gml:Polygon' || _.name === 'gml:Rectangle') {
 		return rewind({
 			type: 'Polygon',
-			coordinates: parsePolygonOrRectangle(_, transformCoords, stride)
+			coordinates: parsePolygonOrRectangle(_, opts, ctx)
 		})
 	} else if (_.name === 'gml:Surface') {
 		return rewind({
 			type: 'MultiPolygon',
-			coordinates: parseSurface(_, transformCoords, stride)
+			coordinates: parseSurface(_, opts, ctx)
 		})
 	} else if (_.name === 'gml:MultiSurface') {
 		return rewind({
 			type: 'MultiPolygon',
-			coordinates: parseMultiSurface(_, transformCoords, stride)
+			coordinates: parseMultiSurface(_, opts, ctx)
 		})
 	}
 	return null // todo

--- a/index.js
+++ b/index.js
@@ -45,16 +45,19 @@ const findIn = (root, ...tags) => {
 
 const createChildContext = (_, opts, ctx) => {
 	const srsDimensionAttribute = _.attributes && _.attributes.srsDimension
+
 	if (srsDimensionAttribute) {
 		const srsDimension = parseInt(srsDimensionAttribute)
-		if (Number.isNaN(srsDimension) || srsDimension <= 0) throw new Error(`invalid srsDimension attribute value "${srsDimensionAttribute}", expected a positive integer`)
+		if (Number.isNaN(srsDimension) || srsDimension <= 0) {
+			throw new Error(`invalid srsDimension attribute value "${srsDimensionAttribute}", expected a positive integer`)
+		}
 
 		const childCtx = Object.create(ctx)
 		childCtx.srsDimension = srsDimension
 		return childCtx;
-	} else {
-		return ctx;
 	}
+
+	return ctx;
 }
 
 const parsePosList = (_, opts, ctx = {}) => {

--- a/readme.md
+++ b/readme.md
@@ -84,11 +84,15 @@ Look at these code examples to understand how to use `parse-gml-polygon`:
 ## API
 
 ```js
-parseGmlPolygon(tree, transformCoords = noTransform, stride = 2) => GeoJSON
+parseGmlPolygon(tree, { transformCoords: noTransform, stride: 2}) => GeoJSON
 ```
 
+Second argument is a map of options:
+
 - You may optionally pass in a `transformCoords` function, e.g. to translate them into WGS84. The default transform is `(x, y) => [x, y]`.
-- `stride` specifies the number of values that each point in the polygon has. A `stride` of `3` would correspond to a polygon in a 3D coordinate system.
+- `stride` specifies the default number of values that each point in the polygon has. A `stride` of `3` would correspond to a polygon in a 3D coordinate system.  
+Please note that this value can be overridden by the `srsDimension` attribute.  
+Default value of `stride` is `2`.
 
 
 ## Unsupported encodings

--- a/test.js
+++ b/test.js
@@ -50,7 +50,7 @@ const point5 = (coords) => {
 	})
 }
 
-const transformCoords = (...vals) => vals.map(val => val * 10)
+const scaleByTen = (...vals) => vals.map(val => val * 10)
 
 // see http://erouault.blogspot.de/2014/04/gml-madness.html
 
@@ -64,7 +64,7 @@ test('Polygon > exterior > LinearRing > posList', (t) => {
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), simpleExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), simpleExterior)
 	t.end()
 })
 
@@ -75,7 +75,7 @@ test('Polygon > exterior > LinearRing > pos*5', (t) => {
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), simpleExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), simpleExterior)
 	t.end()
 })
 
@@ -86,7 +86,7 @@ test('Polygon > exterior > LinearRing > Point*5 > pos', (t) => {
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), simpleExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), simpleExterior)
 	t.end()
 })
 
@@ -97,7 +97,7 @@ test('Rectangle > exterior > LinearRing > posList', (t) => {
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), simpleExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), simpleExterior)
 	t.end()
 })
 
@@ -112,7 +112,7 @@ test('Polygon > exterior > Ring > curveMember > LineString > posList', (t) => {
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), simpleExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), simpleExterior)
 	t.end()
 })
 
@@ -127,7 +127,7 @@ test('Polygon > exterior > Ring > curveMember > LineString > pos*5', (t) => {
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), simpleExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), simpleExterior)
 	t.end()
 })
 
@@ -151,7 +151,7 @@ test('Polygon > exterior > Ring > curveMember*3 > LineString > posList', (t) => 
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), simpleExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), simpleExterior)
 	t.end()
 })
 
@@ -177,7 +177,7 @@ test('Polygon > exterior > Ring > curveMember*2 > Curve > segments > LineStringS
 	])
 	// console.error(require('util').inspect(p, {depth: Infinity}))
 
-	t.deepEqual(parse(p, transformCoords), simpleExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), simpleExterior)
 	t.end()
 })
 
@@ -198,7 +198,7 @@ test('Polygon > exterior > Ring > curveMember > Curve > segments > LineStringSeg
 	])
 	// console.error(require('util').inspect(p, {depth: Infinity}))
 
-	t.deepEqual(parse(p, transformCoords), simpleExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), simpleExterior)
 	t.end()
 })
 
@@ -218,7 +218,7 @@ test('Surface > patches > PolygonPatch > exterior > LinearRing > posList', (t) =
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), multiExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), multiExterior)
 	t.end()
 })
 
@@ -238,7 +238,7 @@ test('Surface > patches > Rectangle*2 > exterior > LinearRing > posList', (t) =>
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), multiExterior)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), multiExterior)
 	t.end()
 })
 
@@ -266,7 +266,7 @@ test('MultiSurface > surfaceMember*2 > Surface > patches > Rectangle > …', (t)
 		h('gml:surfaceMember', [s2])
 	])
 
-	t.deepEqual(parse(m, transformCoords), multiExterior)
+	t.deepEqual(parse(m, {transformCoords : scaleByTen}), multiExterior)
 	t.end()
 })
 
@@ -286,7 +286,7 @@ test('MultiSurface > surfaceMember*2 > Polygon > …', (t) => {
 		h('gml:surfaceMember', [p2])
 	])
 
-	t.deepEqual(parse(m, transformCoords), multiExterior)
+	t.deepEqual(parse(m, {transformCoords : scaleByTen}), multiExterior)
 	t.end()
 })
 
@@ -310,7 +310,7 @@ test('MultiSurface > surfaceMember > CompositeSurface > surfaceMember > Polygon 
 		])
 	])
 
-	t.deepEqual(parse(m, transformCoords), multiExterior)
+	t.deepEqual(parse(m, {transformCoords : scaleByTen}), multiExterior)
 	t.end()
 })
 
@@ -324,7 +324,7 @@ test('Polygon > exterior+interior > LinearRing > posList', (t) => {
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords), withHole)
+	t.deepEqual(parse(p, {transformCoords : scaleByTen}), withHole)
 	t.end()
 })
 
@@ -341,7 +341,7 @@ test('stride === 3', (t) => {
 		])
 	])
 
-	t.deepEqual(parse(p, transformCoords, 3), rewind({
+	t.deepEqual(parse(p, { transformCoords: scaleByTen, stride: 3 }), rewind({
 		type: 'Polygon',
 		coordinates: [[
 			[10, 10, 0],
@@ -386,6 +386,33 @@ test('posList with srsDimension of 3', (t) => {
 	}))
 	t.end()
 })
+
+test('posList with invalid srsDimension of "three"', (t) => {
+	const p = h('gml:Polygon', [
+		h('gml:exterior', [
+			h('gml:LinearRing', [
+				h('gml:posList', {srsDimension: 'three'})
+			])
+		])
+	])
+
+	t.throws(()=>(parse(p), /invalid srsDimension attribute value "three", expected a positive integer/))
+	t.end()
+})
+
+test('posList with invalid srsDimension of "-3"', (t) => {
+	const p = h('gml:Polygon', [
+		h('gml:exterior', [
+			h('gml:LinearRing', [
+				h('gml:posList', {srsDimension: '-3'})
+			])
+		])
+	])
+
+	t.throws(()=>(parse(p), /invalid srsDimension attribute value "-3", expected a positive integer/))
+	t.end()
+})
+
 
 // todo: Polygon > exterior > Ring > curveMember > Curve > segments > LineStringSegment*4 > pointProperty*2 > Point > pos
 // todo: Polygon > exterior > Ring > curveMember > CompositeCurve > curveMember > LineString > posList


### PR DESCRIPTION
This fixes #4, all `parse`-functions now have `(data, opts, ctx)` signature.

I've also updated the documentation.

What I *didn't* do is bump the version in `package.json`. This is a breaking change so it should be `1.x.x` I guess, but I'm not sure what your policy on versions is.

Also sorry the "ignoring Eclipse project files" commits appear again. I don't know why. :(