### PR TITLE
use ES6 imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const deepStrictEqual = require('deep-strict-equal')
-const rewind = require('@turf/rewind')
+import deepStrictEqual from 'deep-strict-equal'
+import rewind from '@turf/rewind'
 
 const noTransform = (...coords) => coords
 
@@ -285,4 +285,5 @@ Object.assign(parse, {
   parseCompositeSurface,
   parseMultiSurface
 })
-module.exports = parse
+
+export default parse

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
-import deepStrictEqual from 'deep-strict-equal'
-import rewind from '@turf/rewind'
+const deepStrictEqual = require('deep-strict-equal')
+const rewind = require('@turf/rewind').default
 
 const noTransform = (...coords) => coords
 
@@ -285,5 +285,4 @@ Object.assign(parse, {
   parseCompositeSurface,
   parseMultiSurface
 })
-
-export default parse
+module.exports = parse


### PR DESCRIPTION
rewind now uses ES6 modules which results in an error when using parse-gml-polygon